### PR TITLE
Fixes issues with files that have query strings appended

### DIFF
--- a/fruitaviaryimageeditor/FruitAviaryImageEditorPlugin.php
+++ b/fruitaviaryimageeditor/FruitAviaryImageEditorPlugin.php
@@ -41,12 +41,12 @@ class FruitAviaryImageEditorPlugin extends BasePlugin
         ));
     }
 
-    public function init() 
+    public function init()
     {
 
 
         if (craft()->request->isCpRequest()) {
-            craft()->templates->includeJsResource('fruitaviaryimageeditor/js/editor.js');
+            craft()->templates->includeJsFile('https://dme0ih8comzn4.cloudfront.net/imaging/v1/editor.js');
             $settings = $this->getSettings();
             $aviaryTools = is_array($settings['aviaryTools']) ? '[\''.implode ("', '", $settings['aviaryTools']).'\']' : '\'all\'';
             $user = craft()->userSession->user;

--- a/fruitaviaryimageeditor/elementactions/FruitAviaryImageEditor_EditImageElementAction.php
+++ b/fruitaviaryimageeditor/elementactions/FruitAviaryImageEditor_EditImageElementAction.php
@@ -18,77 +18,12 @@ class FruitAviaryImageEditor_EditImageElementAction extends BaseElementAction
 		$fileExtensions = craft()->config->get('fileExtensions', 'fruitaviaryimageeditor');
 		$fileExtensionsJSArray = '[\''.implode ("', '", $fileExtensions).'\']';
 
-		$js = <<<EOT
-(function()
-{
+		craft()->templates->includeJsResource('fruitaviaryimageeditor/js/actionTrigger.js');
 
-	var trigger = new Craft.ElementActionTrigger({
-		handle: '{$this->classHandle}',
-		batch: false,
-		validateSelection: function(\$selectedItems)
-		{
-			var \$element = \$selectedItems.find('.element'),
-			fileExtension = \$element.data('url').split('.').pop().toLowerCase();
 
-			if('{$settings['aviaryApiKey']}' == '')
-			{
-				return false;
-			}
-			if(\$.inArray(fileExtension, {$fileExtensionsJSArray}) != -1)
-			{
-				return true;
-			}
-			else
-			{
-				return false;
-			}
-		},
-		activate: function(\$selectedItems)
-		{
-			var \$element = \$selectedItems.find('.element'),
-				id = \$element.data('id'),
-				uid = 'fruitImageEdit' + id,
-				url = \$element.data('url');
-		
-			var img = \$('<img style="display: none;" id="' + uid + '">');
-			img.attr('src', url);
-			img.appendTo('body');
+		$js = "new Craft.AviaryActionTrigger('".$this->classHandle."', '".$settings['aviaryApiKey']."', ".$fileExtensionsJSArray.", ".($settings['imageOverwrite'] ? 'true' : 'false').");";
 
-			var options = {
-				onClose: function() { 
-					$('#' + uid ).remove();
-				},
-				onSave: function(imageID, newURL) {
-					var data = {
-						folderId: Craft.elementIndex.\$source.data('key').split(':')[1],
-						fileName: \$element.data('url').split('/').pop(),
-						aviaryPath: newURL,
-						imageOverwrite: '{$settings['imageOverwrite']}'
-					};
-					Craft.postActionRequest('fruitAviaryImageEditor/saveImage', data, function(response){
-
-						if(response.success)
-						{
-							Craft.elementIndex.updateElements();
-							Fruit.featherEditor.close();
-							if(response.imageOverwrite)
-							{
-								location.reload(true); // To Do : Must be a better way to update the image thumbnail.
-							}						
-						}
-						else
-						{
-							console.log('saveAsset Failed');
-						}
-					});
-					
-				},
-			}
-			Fruit.launchEditor(uid, url, options);
-		}
-	});
-})();
-EOT;
 		craft()->templates->includeJs($js);
+
 	}
 }

--- a/fruitaviaryimageeditor/resources/js/actionTrigger.js
+++ b/fruitaviaryimageeditor/resources/js/actionTrigger.js
@@ -1,0 +1,98 @@
+(function($){
+
+/**
+ * AviaryActionTrigger Class
+ */
+Craft.AviaryActionTrigger = Garnish.Base.extend(
+{
+
+	classHandle: null,
+	aviaryApiKey: null,
+	fileExtensionsJSArray: null,
+	imageOverwrite: null,
+
+	init: function(classHandle, aviaryApiKey, fileExtensionsJSArray, imageOverwrite)
+	{
+
+		this.classHandle = classHandle;
+		this.aviaryApiKey = aviaryApiKey;
+		this.fileExtensionsJSArray = fileExtensionsJSArray;
+		this.imageOverwrite = imageOverwrite;
+
+		var that = this;
+
+		var trigger = new Craft.ElementActionTrigger({
+			handle: that.classHandle,
+			batch: false,
+			validateSelection: function($selectedItems)
+			{
+
+				var $element = $selectedItems.find('.element'),
+						fileExtension = $element.data('url').split('.').pop().toLowerCase(),
+						fileExtension = fileExtension.split('?')[0].toLowerCase();
+
+				if(that.aviaryApiKey == '')
+				{
+					return false;
+				}
+				if($.inArray(fileExtension, that.fileExtensionsJSArray) != -1)
+				{
+					return true;
+				}
+				else
+				{
+					return false;
+				}
+			},
+			activate: function($selectedItems)
+			{
+
+				var $element = $selectedItems.find('.element'),
+						id = $element.data('id'),
+						uid = 'fruitImageEdit' + id,
+						url = $element.data('url');
+
+				var img = $('<img style="display: none;" id="' + uid + '">');
+				img.attr('src', url);
+				img.appendTo('body');
+
+				var options = {
+					onClose: function() {
+						$('#' + uid ).remove();
+					},
+					onSave: function(imageID, newURL) {
+						var data = {
+							folderId: Craft.elementIndex.$source.data('key').split(':')[1],
+							fileName: $element.data('url').split('/').pop(),
+							aviaryPath: newURL,
+							imageOverwrite: that.imageOverwrite
+						};
+						Craft.postActionRequest('fruitAviaryImageEditor/saveImage', data, function(response){
+
+							if(response.success)
+							{
+								Craft.elementIndex.updateElements();
+								Fruit.featherEditor.close();
+								if(response.imageOverwrite)
+								{
+									location.reload(true); // To Do : Must be a better way to update the image thumbnail.
+								}
+							}
+							else
+							{
+								console.log('saveAsset Failed');
+							}
+						});
+
+					},
+				}
+
+				Fruit.launchEditor(uid, url, options);
+			}
+		});
+
+	}
+
+});
+
+})(jQuery);

--- a/fruitaviaryimageeditor/services/FruitAviaryImageEditorService.php
+++ b/fruitaviaryimageeditor/services/FruitAviaryImageEditorService.php
@@ -6,6 +6,8 @@ class FruitAviaryImageEditorService extends BaseApplicationComponent
     public function saveImage($folderId, $fileName, $aviaryPath, $imageOverwrite)
     {
 
+    $fileName = explode('?', $fileName)[0];
+
 		$folder = craft()->assets->getFolderById($folderId);
 
 		$ch = curl_init();


### PR DESCRIPTION
I'm not sure if you even want or welcome PRs for this, but what the heck - I had to do a fair bit of hacking to get this to work for our situation so thought I'd share it with you guys.

I have added support for files with query strings such as those generated by Assets and S3 when the Cache Duration is set on a given Asset Source.

I also extracted the action trigger js to a separate file as part of my debugging process, it made it easier to develop and spot the issue.

Finally, I switched to using the editor.js file that Adobe host and maintain, for the sake of reducing any potential issues they have fixed in there.

I've also played with adding some preset values for the crop tool, but at present they are hardcoded so I'm leaving them out of this PR but I'm thinking of adding crop defaults for any transforms saved in the cp.

Great plugin, our clients love it!